### PR TITLE
wip: make Edge Runtime work by roughing up the Node SDK

### DIFF
--- a/packages/node-sdk/src/cache.ts
+++ b/packages/node-sdk/src/cache.ts
@@ -1,4 +1,4 @@
-import { Cache, Logger } from "./types";
+import type { Cache, Logger } from "./types";
 
 /**
  * Create a cached function that updates the value asynchronously.
@@ -43,13 +43,16 @@ export default function cache<T>(
       logger?.error("failed to update cached value", e);
     } finally {
       refreshPromise = undefined;
-      timeoutId = setTimeout(update, ttl).unref();
+      timeoutId = setTimeout(update, ttl);
+      if (timeoutId.unref) {
+        timeoutId.unref();
+      }
     }
   };
 
   const get = () => {
     if (lastUpdate !== undefined) {
-      const age = Date.now() - lastUpdate!;
+      const age = Date.now() - lastUpdate as number;
       if (age > staleTtl) {
         logger?.warn("cached value is stale", { age, cachedValue });
       }

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 import { evaluateFeatureRules, flattenJSON } from "@bucketco/flag-evaluation";
 
 import BatchBuffer from "./batch-buffer";
@@ -51,7 +49,6 @@ import {
   once,
 } from "./utils";
 
-const bucketConfigDefaultFile = "bucketConfig.json";
 
 type BulkEvent =
   | {
@@ -205,14 +202,6 @@ export class BucketClient {
           options.fetchTimeoutMs >= 0),
       "fetchTimeoutMs must be a non-negative integer",
     );
-
-    if (!options.configFile) {
-      options.configFile =
-        (process.env.BUCKET_CONFIG_FILE ??
-        fs.existsSync(bucketConfigDefaultFile))
-          ? bucketConfigDefaultFile
-          : undefined;
-    }
 
     const externalConfig = loadConfig(options.configFile);
     const config = mergeSkipUndefined(externalConfig, options);

--- a/packages/node-sdk/src/config.ts
+++ b/packages/node-sdk/src/config.ts
@@ -1,9 +1,4 @@
-import { readFileSync } from "fs";
-
 import { version } from "../package.json";
-
-import { LOG_LEVELS } from "./types";
-import { isObject, ok } from "./utils";
 
 export const API_BASE_URL = "https://front.bucket.co";
 export const SDK_VERSION_HEADER_NAME = "bucket-sdk-version";
@@ -19,72 +14,6 @@ export const FEATURES_REFETCH_MS = 60 * 1000; // re-fetch every 60 seconds
 
 export const BATCH_MAX_SIZE = 100;
 export const BATCH_INTERVAL_MS = 10 * 1000;
-
-function parseOverrides(config: object | undefined) {
-  if (!config) return {};
-  if ("featureOverrides" in config && isObject(config.featureOverrides)) {
-    Object.entries(config.featureOverrides).forEach(([key, value]) => {
-      ok(
-        typeof value === "boolean" || isObject(value),
-        `invalid type "${typeof value}" for key ${key}, expected boolean or object`,
-      );
-      if (isObject(value)) {
-        ok(
-          "isEnabled" in value && typeof value.isEnabled === "boolean",
-          `invalid type "${typeof value.isEnabled}" for key ${key}.isEnabled, expected boolean`,
-        );
-        ok(
-          value.config === undefined || isObject(value.config),
-          `invalid type "${typeof value.config}" for key ${key}.config, expected object or undefined`,
-        );
-        if (isObject(value.config)) {
-          ok(
-            "key" in value.config && typeof value.config.key === "string",
-            `invalid type "${typeof value.config.key}" for key ${key}.config.key, expected string`,
-          );
-        }
-      }
-    });
-
-    return config.featureOverrides;
-  }
-
-  return {};
-}
-
-function loadConfigFile(file: string) {
-  const configJson = readFileSync(file, "utf-8");
-  const config = JSON.parse(configJson);
-
-  ok(typeof config === "object", "config must be an object");
-  const { secretKey, logLevel, offline, host, apiBaseUrl } = config;
-
-  ok(
-    typeof secretKey === "undefined" || typeof secretKey === "string",
-    "secret must be a string",
-  );
-  ok(
-    typeof apiBaseUrl === "undefined" || typeof apiBaseUrl === "string",
-    "apiBaseUrl must be a string",
-  );
-  ok(
-    typeof logLevel === "undefined" ||
-      (typeof logLevel === "string" && LOG_LEVELS.includes(logLevel as any)),
-    `logLevel must one of ${LOG_LEVELS.join(", ")}`,
-  );
-  ok(
-    typeof offline === "undefined" || typeof offline === "boolean",
-    "offline must be a boolean",
-  );
-
-  return {
-    featureOverrides: parseOverrides(config),
-    secretKey,
-    logLevel,
-    offline,
-    apiBaseUrl: host ?? apiBaseUrl,
-  };
-}
 
 function loadEnvVars() {
   const secretKey = process.env.BUCKET_SECRET_KEY;
@@ -127,20 +56,17 @@ function loadEnvVars() {
 }
 
 export function loadConfig(file?: string) {
-  let fileConfig;
   if (file) {
-    fileConfig = loadConfigFile(file);
+    throw new Error("file not supported");
   }
-
   const envConfig = loadEnvVars();
 
   return {
-    secretKey: envConfig.secretKey || fileConfig?.secretKey,
-    logLevel: envConfig.logLevel || fileConfig?.logLevel,
-    offline: envConfig.offline ?? fileConfig?.offline,
-    apiBaseUrl: envConfig.apiBaseUrl ?? fileConfig?.apiBaseUrl,
+    secretKey: envConfig.secretKey,
+    logLevel: envConfig.logLevel,
+    offline: envConfig.offline,
+    apiBaseUrl: envConfig.apiBaseUrl,
     featureOverrides: {
-      ...fileConfig?.featureOverrides,
       ...envConfig.featureOverrides,
     },
   };

--- a/packages/node-sdk/src/flusher.ts
+++ b/packages/node-sdk/src/flusher.ts
@@ -1,5 +1,3 @@
-import { constants } from "os";
-
 import { END_FLUSH_TIMEOUT_MS } from "./config";
 import { TimeoutError, withTimeout } from "./utils";
 
@@ -38,25 +36,39 @@ export function subscribe(
     state = true;
   };
 
-  killSignals.forEach((signal) => {
-    const hasListeners = process.listenerCount(signal) > 0;
+  // Edge runtime does not support node:os import or process.listenerCount below
+  if (typeof EdgeRuntime !== "string") {
+    const importOs = import("node:os").catch(() => {
+      console.error(
+        "[Bucket SDK] Failed to import node:os. Cannot listen to process events.",
+      );
+    });
 
-    if (hasListeners) {
-      process.prependListener(signal, wrappedCallback);
-    } else {
-      process.on(signal, async () => {
-        await wrappedCallback();
-        process.exit(0x80 + constants.signals[signal]);
+    for (const signal of killSignals) {
+      if (typeof process.listenerCount !== "function") continue;
+      void importOs.then((os) => {
+        if (!os) return;
+        const hasListeners = process.listenerCount(signal) > 0;
+
+        if (hasListeners) {
+          process.prependListener(signal, wrappedCallback);
+        } else {
+          process.on(signal, async () => {
+            await wrappedCallback();
+            process.exit(0x80 + os.constants.signals[signal]);
+          });
+        }
       });
     }
-  });
 
-  process.on("beforeExit", wrappedCallback);
-  process.on("exit", () => {
-    if (!state) {
-      console.error(
-        "[Bucket SDK] Failed to finalize the flushing of events on process exit.",
-      );
-    }
-  });
+    if (typeof process.on !== "function") return;
+    process.on("beforeExit", wrappedCallback);
+    process.on("exit", () => {
+      if (!state) {
+        console.error(
+          "[Bucket SDK] Failed to finalize the flushing of events on process exit.",
+        );
+      }
+    });
+  }
 }

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -2,6 +2,10 @@
 
 import { RuleFilter } from "@bucketco/flag-evaluation";
 
+declare global {
+  const EdgeRuntime: string | undefined;
+}
+
 /**
  * Describes the meta context associated with tracking.
  **/


### PR DESCRIPTION
This draft scopes out conflicts with the Edge Runtime:

- `timeout.unref()` is undefined
- `fs` imports at the module level (we can use `import()` but it forces some sync functions to become async)
- `process.listenerCount`
- `os.constants`